### PR TITLE
Move canonical data to fixtures

### DIFF
--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -18,8 +18,9 @@ module Generator
         filename(exercise_name)[0..-2].split('_').map(&:capitalize).join
       end
 
+      # TODO: for backwards compatibility, remove post-conversion
       def proc_name(exercise_name)
-        "#{class_name(exercise_name)}s"
+        class_name(exercise_name) + 's'
       end
 
       def exercise_name(filename)

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -14,8 +14,12 @@ module Generator
         "#{exercise_name.tr('-', '_')}_cases"
       end
 
+      def class_name(exercise_name)
+        filename(exercise_name)[0..-2].split('_').map(&:capitalize).join
+      end
+
       def proc_name(exercise_name)
-        filename(exercise_name).split('_').map(&:capitalize).join
+        "#{class_name(exercise_name)}s"
       end
 
       def exercise_name(filename)

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -16,55 +16,62 @@ module Generator
 
   module TemplateValuesFactory
     def template_values
-      require cases_require_name
-
       TemplateValues.new(
         abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
         version: version,
-        test_cases: test_cases
+        test_cases: CaseValues.extract(exercise_name: exercise_name, exercise_data: canonical_data.to_s)
       )
+    end
+  end
+
+  class CaseValues
+    def self.extract(exercise_name:, exercise_data:)
+      CaseValues.new(exercise_name: exercise_name, exercise_data: exercise_data).extract
+    end
+
+    def initialize(exercise_name:, exercise_data:)
+      @exercise_name = exercise_name
+      @exercise_data = exercise_data
+
+      require cases_require_name
+    end
+
+    attr_reader :exercise_name, :exercise_data
+
+    def extract
+      # TODO: for backwards compatibility, remove post-conversion
+      return test_cases_proc.call(exercise_data) if test_cases_proc
+
+      extract_test_cases.
+        map.with_index {|test, index| test_case_class.new(test.merge('index' => index)) }
     end
 
     private
 
-    def cases_require_name
-      Files::GeneratorCases.filename(exercise_name)
-    end
-
-    def test_cases
-      if test_cases_proc?
-        test_cases_proc.call(canonical_data.to_s)
-      else
-        test_cases_with_index
-      end
-    end
-
-    def test_cases_with_index
-      extract_test_cases.compact.
-        map.with_index {|test, index| test_case_class.new(test.merge('index' => index)) }
-    end
-
-    def extract_test_cases(data = JSON.parse(canonical_data.to_s)['cases'])
-      data.flat_map do |entry|
-        entry.key?('cases') ? extract_test_cases(entry['cases']) : entry
-      end
-    end
-
-    def test_cases_proc?
-      Object.const_defined?(test_cases_procname)
-    end
-
+    # TODO: for backwards compatibility, remove post-conversion
     def test_cases_proc
-      Object.const_get(test_cases_procname)
+      if Object.const_defined?(test_cases_procname)
+        Object.const_get(test_cases_procname)
+      end
+    end
+
+    # TODO: for backwards compatibility, remove post-conversion
+    def test_cases_procname
+      @test_cases_procname ||= Files::GeneratorCases.proc_name(exercise_name)
+    end
+
+    def extract_test_cases(data: JSON.parse(exercise_data)['cases'])
+      data.flat_map do |entry|
+        entry.key?('cases') ? extract_test_cases(data: entry['cases']) : entry
+      end
     end
 
     def test_case_class
       Object.const_get(Files::GeneratorCases.class_name(exercise_name))
     end
 
-    def test_cases_procname
-      @test_cases_procname ||= Files::GeneratorCases.proc_name(exercise_name)
+    def cases_require_name
+      Files::GeneratorCases.filename(exercise_name)
     end
-
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -21,7 +21,7 @@ module Generator
       TemplateValues.new(
         abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
         version: version,
-        test_cases: test_cases_proc.call(canonical_data.to_s)
+        test_cases: test_cases
       )
     end
 
@@ -31,8 +31,40 @@ module Generator
       Files::GeneratorCases.filename(exercise_name)
     end
 
-    def test_cases_proc
-      Object.const_get(Files::GeneratorCases.proc_name(exercise_name))
+    def test_cases
+      if test_cases_proc?
+        test_cases_proc.call(canonical_data.to_s)
+      else
+        test_cases_with_index
+      end
     end
+
+    def test_cases_with_index
+      extract_test_cases.compact.
+        map.with_index {|test, index| test_case_class.new(test.merge('index' => index)) }
+    end
+
+    def extract_test_cases(data = JSON.parse(canonical_data.to_s)['cases'])
+      data.flat_map do |entry|
+        entry.key?('cases') ? extract_test_cases(entry['cases']) : entry
+      end
+    end
+
+    def test_cases_proc?
+      Object.const_defined?(test_cases_procname)
+    end
+
+    def test_cases_proc
+      Object.const_get(test_cases_procname)
+    end
+
+    def test_case_class
+      Object.const_get(Files::GeneratorCases.class_name(exercise_name))
+    end
+
+    def test_cases_procname
+      @test_cases_procname ||= Files::GeneratorCases.proc_name(exercise_name)
+    end
+
   end
 end

--- a/test/fixtures/metadata/exercises/complex/canonical-data.json
+++ b/test/fixtures/metadata/exercises/complex/canonical-data.json
@@ -1,0 +1,45 @@
+{
+  "exercise": "beer-song",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "verse",
+      "cases": [
+        {
+          "description": "single verse",
+          "cases": [
+            {
+              "description": "first generic verse",
+              "property": "verse",
+              "number": 99,
+              "expected": "99 bottles of beer on the wall, YAAAR"
+            },
+            {
+              "description": "last generic verse",
+              "property": "verse",
+              "number": 3,
+              "expected": "3 bottles of beer on the wall, YAAAR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "lyrics",
+      "cases": [
+        {
+          "description": "multiple verses",
+          "cases": [
+            {
+              "description": "first two verses",
+              "property": "verses",
+              "beginning": 99,
+              "end": 98,
+              "expected": "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/metadata/exercises/simple/canonical-data.json
+++ b/test/fixtures/metadata/exercises/simple/canonical-data.json
@@ -1,0 +1,10 @@
+{
+	"description": "Test canonical data",
+	"cases": [
+		{
+			"description": "add 2 numbers",
+			"input": [1,1],
+			"expected": 2
+		}
+	]
+}

--- a/test/fixtures/xruby/lib/gamma_cases.rb
+++ b/test/fixtures/xruby/lib/gamma_cases.rb
@@ -1,0 +1,7 @@
+class GammaCase < ExerciseCase
+
+  def workload
+    assert { Gamma.foo(bar) }
+  end
+
+end

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -10,7 +10,7 @@ module Generator
 
       def test_cases_found
         track_path = 'test/fixtures/xruby'
-        assert_equal %w(alpha beta), GeneratorCases.available(track_path).sort
+        assert_equal %w(alpha beta gamma), GeneratorCases.available(track_path).sort
       end
 
       def test_available_returns_exercise_names

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -25,6 +25,10 @@ module Generator
         assert_equal 'two_parter_cases', GeneratorCases.filename(exercise_name)
       end
 
+      def test_class_name
+        assert_equal 'TwoParterCase', GeneratorCases.class_name('two-parter')
+      end
+
       def test_proc_name
         exercise_name = 'two-parter'
         assert_equal 'TwoParterCases', GeneratorCases.proc_name(exercise_name)

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -56,4 +56,115 @@ module Generator
       $LOAD_PATH.delete 'test/fixtures/xruby/lib'
     end
   end
+
+  class CaseValuesTest < Minitest::Test
+    def setup
+      $LOAD_PATH.unshift 'test/fixtures/xruby/lib'
+    end
+
+    def simple_canonical_data
+      simple_canonical_data = Minitest::Mock.new
+      simple_canonical_data.expect(
+        :to_s,
+        <<-TEXT
+{
+	"description": "Test canonical data",
+	"cases": [
+	{
+		"description": "add 2 numbers",
+		"input": [1,1],
+		"expected": 2
+	}
+	]
+}
+TEXT
+      )
+      simple_canonical_data
+    end
+
+    def complex_canonical_data
+      complex_canonical_data = Minitest::Mock.new
+      complex_canonical_data.expect(
+        :to_s,
+        <<-TEXT
+{
+  "exercise": "beer-song",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "verse",
+      "cases": [
+        {
+          "description": "single verse",
+          "cases": [
+            {
+              "description": "first generic verse",
+              "property": "verse",
+              "number": 99,
+              "expected": "99 bottles of beer on the wall, YAAAR"
+            },
+            {
+              "description": "last generic verse",
+              "property": "verse",
+              "number": 3,
+              "expected": "3 bottles of beer on the wall, YAAAR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "lyrics",
+      "cases": [
+        {
+          "description": "multiple verses",
+          "cases": [
+            {
+              "description": "first two verses",
+              "property": "verses",
+              "beginning": 99,
+              "end": 98,
+              "expected": "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+TEXT
+      )
+      complex_canonical_data
+    end
+
+    def test_extract_via_proc
+      cases = CaseValues.extract(exercise_name: 'alpha', exercise_data: simple_canonical_data.to_s)
+      expected = [AlphaCase.new(description: 'add 2 numbers', input: [1, 1], expected: 2, index: 0)]
+      assert_equal expected.to_s, cases.to_s
+    end
+
+    def test_simple_auto_extraction
+      cases = CaseValues.extract(exercise_name: 'gamma', exercise_data: simple_canonical_data.to_s)
+      expected = [GammaCase.new(description: 'add 2 numbers', input: [1, 1], expected: 2, index: 0)]
+      assert_equal expected.to_s, cases.to_s
+    end
+
+    def test_multi_level_auto_extraction
+      cases = CaseValues.extract(exercise_name: 'gamma', exercise_data: complex_canonical_data.to_s)
+      expected = [
+        GammaCase.new(description: 'first generic verse', property: 'verse', number: 99,
+                      expected: '99 bottles of beer on the wall, YAAAR', index: 0),
+        GammaCase.new(description: 'last generic verse', property: 'verse', number: 3,
+                      expected: '3 bottles of beer on the wall, YAAAR', index: 1),
+        GammaCase.new(description: 'first two verses', property: 'verses', beginning: 99, end: 98,
+                      expected: "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT", index: 2),
+
+      ]
+      assert_equal expected.to_s, cases.to_s
+    end
+
+    def teardown
+      $LOAD_PATH.delete 'test/fixtures/xruby/lib'
+    end
+  end
 end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -62,61 +62,6 @@ module Generator
       $LOAD_PATH.unshift 'test/fixtures/xruby/lib'
     end
 
-    def complex_canonical_data
-      complex_canonical_data = Minitest::Mock.new
-      complex_canonical_data.expect(
-        :to_s,
-        <<-TEXT
-{
-  "exercise": "beer-song",
-  "version": "1.0.0",
-  "cases": [
-    {
-      "description": "verse",
-      "cases": [
-        {
-          "description": "single verse",
-          "cases": [
-            {
-              "description": "first generic verse",
-              "property": "verse",
-              "number": 99,
-              "expected": "99 bottles of beer on the wall, YAAAR"
-            },
-            {
-              "description": "last generic verse",
-              "property": "verse",
-              "number": 3,
-              "expected": "3 bottles of beer on the wall, YAAAR"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "lyrics",
-      "cases": [
-        {
-          "description": "multiple verses",
-          "cases": [
-            {
-              "description": "first two verses",
-              "property": "verses",
-              "beginning": 99,
-              "end": 98,
-              "expected": "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
-TEXT
-      )
-      complex_canonical_data
-    end
-
     def test_extract_via_proc
       simple_canonical_data = File.read('test/fixtures/metadata/exercises/simple/canonical-data.json')
       cases = CaseValues.extract(exercise_name: 'alpha', exercise_data: simple_canonical_data.to_s)
@@ -132,6 +77,7 @@ TEXT
     end
 
     def test_multi_level_auto_extraction
+      complex_canonical_data = File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
       cases = CaseValues.extract(exercise_name: 'gamma', exercise_data: complex_canonical_data.to_s)
       expected = [
         GammaCase.new(description: 'first generic verse', property: 'verse', number: 99,

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -62,26 +62,6 @@ module Generator
       $LOAD_PATH.unshift 'test/fixtures/xruby/lib'
     end
 
-    def simple_canonical_data
-      simple_canonical_data = Minitest::Mock.new
-      simple_canonical_data.expect(
-        :to_s,
-        <<-TEXT
-{
-	"description": "Test canonical data",
-	"cases": [
-	{
-		"description": "add 2 numbers",
-		"input": [1,1],
-		"expected": 2
-	}
-	]
-}
-TEXT
-      )
-      simple_canonical_data
-    end
-
     def complex_canonical_data
       complex_canonical_data = Minitest::Mock.new
       complex_canonical_data.expect(
@@ -138,12 +118,14 @@ TEXT
     end
 
     def test_extract_via_proc
+      simple_canonical_data = File.read('test/fixtures/metadata/exercises/simple/canonical-data.json')
       cases = CaseValues.extract(exercise_name: 'alpha', exercise_data: simple_canonical_data.to_s)
       expected = [AlphaCase.new(description: 'add 2 numbers', input: [1, 1], expected: 2, index: 0)]
       assert_equal expected.to_s, cases.to_s
     end
 
     def test_simple_auto_extraction
+      simple_canonical_data = File.read('test/fixtures/metadata/exercises/simple/canonical-data.json')
       cases = CaseValues.extract(exercise_name: 'gamma', exercise_data: simple_canonical_data.to_s)
       expected = [GammaCase.new(description: 'add 2 numbers', input: [1, 1], expected: 2, index: 0)]
       assert_equal expected.to_s, cases.to_s


### PR DESCRIPTION
Here is an example of moving the sample json data into fixtures rather than storing it inline in the test file.