### PR TITLE
Refactor Extractor

### DIFF
--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -2,23 +2,23 @@ module Generator
   module CaseValues
 
     class Extractor
-      attr_reader :exercise_name, :exercise_data
+      attr_reader :exercise_name
 
-      def initialize(exercise_name:, exercise_data:, case_class:)
+      def initialize(exercise_name:, case_class:)
         @exercise_name = exercise_name
-        @exercise_data = exercise_data
         @case_class = case_class
       end
 
-      def extract(_)
-        extract_test_cases.map.with_index do |test, index|
+      def extract(exercise_data)
+        parsed_data = JSON.parse(exercise_data)['cases']
+        extract_test_cases(data: parsed_data).map.with_index do |test, index|
           @case_class.new(test.merge('index' => index))
         end
       end
 
       private
 
-      def extract_test_cases(data: JSON.parse(exercise_data)['cases'])
+      def extract_test_cases(data:)
         data.flat_map do |entry|
           entry.key?('cases') ? extract_test_cases(data: entry['cases']) : entry
         end

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -4,21 +4,15 @@ module Generator
     class Extractor
       attr_reader :exercise_name, :exercise_data
 
-      def self.extract(exercise_name:, exercise_data:)
-        self.new(
-          exercise_name: exercise_name,
-          exercise_data: exercise_data
-        ).extract
-      end
-
-      def initialize(exercise_name:, exercise_data:)
+      def initialize(exercise_name:, exercise_data:, case_class:)
         @exercise_name = exercise_name
         @exercise_data = exercise_data
+        @case_class = case_class
       end
 
       def extract(_)
         extract_test_cases.map.with_index do |test, index|
-          test_case_class.new(test.merge('index' => index))
+          @case_class.new(test.merge('index' => index))
         end
       end
 
@@ -28,10 +22,6 @@ module Generator
         data.flat_map do |entry|
           entry.key?('cases') ? extract_test_cases(data: entry['cases']) : entry
         end
-      end
-
-      def test_case_class
-        Object.const_get(Files::GeneratorCases.class_name(exercise_name))
       end
     end
   end

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -5,7 +5,7 @@ module Generator
         @case_class = case_class
       end
 
-      def extract(exercise_data)
+      def call(exercise_data)
         parsed_data = JSON.parse(exercise_data)['cases']
         extract_test_cases(data: parsed_data).map.with_index do |test, index|
           @case_class.new(test.merge('index' => index))

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -1,11 +1,7 @@
 module Generator
   module CaseValues
-
     class Extractor
-      attr_reader :exercise_name
-
-      def initialize(exercise_name:, case_class:)
-        @exercise_name = exercise_name
+      def initialize(case_class:)
         @case_class = case_class
       end
 

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -16,7 +16,7 @@ module Generator
         @exercise_data = exercise_data
       end
 
-      def extract
+      def extract(_)
         extract_test_cases.map.with_index do |test, index|
           test_case_class.new(test.merge('index' => index))
         end
@@ -34,6 +34,5 @@ module Generator
         Object.const_get(Files::GeneratorCases.class_name(exercise_name))
       end
     end
-
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -27,7 +27,7 @@ module Generator
 
     def extract
       load cases_load_name
-      extractor.extract(canonical_data.to_s)
+      extractor.call(canonical_data.to_s)
     end
 
     def extractor

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -33,8 +33,7 @@ module Generator
     def extractor
         CaseValues::Extractor.new(
           case_class: Object.const_get(Files::GeneratorCases.class_name(exercise_name)),
-          exercise_name: exercise_name,
-          exercise_data: canonical_data.to_s
+          exercise_name: exercise_name
         )
     end
 

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -27,11 +27,10 @@ module Generator
 
     def extract
       load cases_load_name
-
-      CaseValues::Extractor.extract(
+      CaseValues::Extractor.new(
         exercise_name: exercise_name,
         exercise_data: canonical_data.to_s
-      )
+      ).extract(canonical_data.to_s)
     end
 
     def cases_load_name

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -27,10 +27,15 @@ module Generator
 
     def extract
       load cases_load_name
-      CaseValues::Extractor.new(
-        exercise_name: exercise_name,
-        exercise_data: canonical_data.to_s
-      ).extract(canonical_data.to_s)
+      extractor.extract(canonical_data.to_s)
+    end
+
+    def extractor
+        CaseValues::Extractor.new(
+          case_class: Object.const_get(Files::GeneratorCases.class_name(exercise_name)),
+          exercise_name: exercise_name,
+          exercise_data: canonical_data.to_s
+        )
     end
 
     def cases_load_name

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -32,8 +32,7 @@ module Generator
 
     def extractor
         CaseValues::Extractor.new(
-          case_class: Object.const_get(Files::GeneratorCases.class_name(exercise_name)),
-          exercise_name: exercise_name
+          case_class: Object.const_get(Files::GeneratorCases.class_name(exercise_name))
         )
     end
 

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -13,7 +13,6 @@ module Generator
         canonical_data = File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
         cases = Extractor.new(
           case_class: ComplexCase,
-          exercise_name: 'complex',
         ).extract(canonical_data)
 
         expected = [

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -10,10 +10,11 @@ module Generator
   module CaseValues
     class ExtractorTest < Minitest::Test
       def test_multi_level_auto_extraction
+        canonical_data = File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
         cases = Extractor.new(
           exercise_name: 'complex',
-          exercise_data: File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
-        ).extract
+          exercise_data: canonical_data
+        ).extract(canonical_data)
 
         expected = [
           ComplexCase.new(description: 'first generic verse', property: 'verse', number: 99,

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -12,8 +12,10 @@ module Generator
       def test_multi_level_auto_extraction
         canonical_data = File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
         cases = Extractor.new(
+          case_class: ComplexCase,
           exercise_name: 'complex',
           exercise_data: canonical_data
+
         ).extract(canonical_data)
 
         expected = [

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -14,8 +14,6 @@ module Generator
         cases = Extractor.new(
           case_class: ComplexCase,
           exercise_name: 'complex',
-          exercise_data: canonical_data
-
         ).extract(canonical_data)
 
         expected = [

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -13,7 +13,7 @@ module Generator
         canonical_data = File.read('test/fixtures/metadata/exercises/complex/canonical-data.json')
         cases = Extractor.new(
           case_class: ComplexCase,
-        ).extract(canonical_data)
+        ).call(canonical_data)
 
         expected = [
           ComplexCase.new(description: 'first generic verse', property: 'verse', number: 99,


### PR DESCRIPTION
By constructing the `Extractor` with just the `cases_class` it needs to create, and passing the data to be parsed to it for extraction,  `Extractor` no longer needs to know anything about the exercise name, or anything from Files::GeneratorCases and everything becomes much simpler.
